### PR TITLE
Version 2.0.4 with support of a timeframed view and banded columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+* Added ability to display bandedcolumns as plotbackground
+* Added the option to more precisely configure the X-axis
+* Added the ability to show a certain timeframe (fixed size or relative)
+
 ## 2.0.3
 * Fixed typo: SelectionBuider changed into SelectionBuilder
 * Added ability to display canvas tooltips

--- a/capabilities.json
+++ b/capabilities.json
@@ -551,8 +551,9 @@
                     "suppressFormatPainterCopy": true
                 },
                 "labelColor": {
-                    "displayName": "Color",
+                    "displayName": "Legend Text Color",
                     "displayNameKey": "Visual_Color",
+                    "description": "Legend Text Color",
                     "type": {
                         "fill": {
                             "solid": {
@@ -654,6 +655,13 @@
                         "formatting": {
                             "fontSize": true
                         }
+                    }
+                },
+                "wordWrap": {
+                    "displayName": "Word wrap",
+                    "displayNameKey": "Visual_wordWrap",
+                    "type": {
+                        "bool": true
                     }
                 },
                 "width": {
@@ -785,12 +793,54 @@
                 }
             }
         },
+        "pasettings": {
+            "displayName": "Plot Area",
+            "displayNameKey": "Visual_PlotArea",
+            "properties": {
+                "show": {
+                    "displayName": "Show",
+                    "displayNameKey": "Visual_Show",
+                    "type": {
+                        "bool": true
+                    }
+                },
+                "paColorOdd": {
+                    "displayName": "Color Columns Odd",
+                    "displayNameKey": "Visual_Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "paColorEven": {
+                    "displayName": "Color Columns Even",
+                    "displayNameKey": "Visual_Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "transparency": {
+                    "displayName": "Transparency",
+                    "description": "Transparency of the color columns",
+                    "type": {
+                        "numeric": true
+                    }
+                }
+            }
+        },
         "dateType": {
             "displayName": "Date type",
             "displayNameKey": "Visual_DateType",
             "properties": {
                 "type": {
-                    "displayName": "Type",
+                    "displayName": "Interval",
                     "displayNameKey": "Visual_Type",
                     "type": {
                         "enumeration": [
@@ -847,6 +897,127 @@
                             }
                         }
                     }
+                }
+            }
+        },
+        "xaxis": {
+            "displayName": "X-axis",
+            "displayNameKey": "Visual_Xaxis",
+            "description": "Display X-axis options",
+            "descriptionKey": "Visual_Description_Xaxis",
+            "properties": {
+                "show": {
+                    "displayName": "Show",
+                    "displayNameKey": "Visual_show",
+                    "type": {
+                        "bool": true
+                    }
+                },
+                "axisRangeType": {
+                    "displayName": "Axis range type",
+                    "displayNameKey": "Visual_Xaxis_AxisRangeType",
+                    "description": "Choose the type of scale of the X-axis. Automatically based on first start date and last end date",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeType",
+                    "type": {
+                        "enumeration": [
+                            {
+                                "value": "auto",
+                                "displayName": "auto (default)",
+                                "displayNameKey": "Visual_Xaxis_AxisRangeType_auto"
+                            },
+                            {
+                                "value": "absolute",
+                                "displayName": "absolute",
+                                "displayNameKey": "Visual_Xaxis_AxisRangeType_absolute"
+                            },
+                            {
+                                "value": "relative",
+                                "displayName": "relative",
+                                "displayNameKey": "Visual_Xaxis_AxisRangeType_relative"
+                            }
+                        ]
+                    }
+                },
+                "axisRangeTypeAbsoluteStartDate": {
+                    "displayName": "Abs start date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_absolute_StartDate",
+                    "type": {
+                        "text": true
+                    },
+                    "description": "Enter the absolute start day (absolute must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeAbsoluteStartDate"
+                },
+                "axisRangeTypeAbsoluteEndDate": {
+                    "displayName": "Abs end date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_absolute_EndDate",
+                    "type": {
+                        "text": true
+                    },
+                    "description": "Enter the absolute end day (absolute must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeAbsoluteEndDate"
+                },
+                "axisRangeTypeRelativeReferenceDateMethod": {
+                    "displayName": "Method to determine the reference date used with the relative option",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate",
+                    "type": {
+                        "enumeration": [
+                            {
+                                "value": "MonthStart",
+                                "displayName": "Current month start",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_MonthStart"
+                            },
+                            {
+                                "value": "MonthMiddle",
+                                "displayName": "Current month middle",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_MonthMiddle"
+                            },
+                            {
+                                "value": "MonthEnd",
+                                "displayName": "Current month end",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_MonthEnd"
+                            },
+                            {
+                                "value": "QuarterStart",
+                                "displayName": "Current quarter start",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_QuarterStart"
+                            },
+                            {
+                                "value": "QuarterMiddle",
+                                "displayName": "Current quarter middle",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_QuarterMiddle"
+                            },
+                            {
+                                "value": "QuarterEnd",
+                                "displayName": "Current quarter end",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_QuarterEnd"
+                            },
+                            {
+                                "value": "Current date",
+                                "displayName": "Current date",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_Current"
+                            }
+                        ]
+                    },
+                    "description": "Enter the reference start day (relative must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeRelativeReferenceDate"
+                },
+                "axisRangeTypeRelativeStartInt": {
+                    "displayName": "Units relative start date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_StartInt",
+                    "type": {
+                        "numeric": true
+                    },
+                    "description": "Enter the amount of intervals (specified in Date type) for the start of the X-axis (relative must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeRelativeStartInt"
+                },
+                "axisRangeTypeRelativeEndInt": {
+                    "displayName": "Units relative end date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_StartInt",
+                    "type": {
+                        "numeric": true
+                    },
+                    "description": "Enter the amount of intervals (specified in Date type) for the end of the X-axis (relative must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeRelativeStartInt"
                 },
                 "axisColor": {
                     "displayName": "Axis Color",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
   "repository": {
     "type": "git",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,10 +1,10 @@
 {
   "visual": {
     "name": "Gantt",
-    "displayName": "Gantt 2.0.3",
+    "displayName": "Gantt 2.0.4",
     "guid": "Gantt1448688115699",
     "visualClassName": "Gantt",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
     "supportUrl": "https://community.powerbi.com",
     "gitHubUrl": "https://github.com/Microsoft/powerbi-visuals-gantt"

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -38,7 +38,9 @@ export class GanttSettings extends DataViewObjectsParser {
     taskConfig: TaskConfigSettings = new TaskConfigSettings();
     taskCompletion: TaskCompletionSettings = new TaskCompletionSettings();
     taskResource: TaskResourceSettings = new TaskResourceSettings();
+    pasettings: PlotAreaSettings = new PlotAreaSettings();
     dateType: DateTypeSettings = new DateTypeSettings();
+    xaxis: customXaxisSettings = new customXaxisSettings();
     tooltipConfig: TooltipConfigSettings = new TooltipConfigSettings();
     milestones: MilestonesSettings = new MilestonesSettings();
 }
@@ -77,6 +79,7 @@ export class TaskLabelsSettings {
     show: boolean = true;
     fill: string = "#000000";
     fontSize: number = 9;
+    wordWrap: boolean = true;
     width: number = 110;
 }
 
@@ -102,8 +105,26 @@ export class DateTypeSettings {
     // tslint:disable-next-line:no-reserved-keywords
     type: DateTypes = DateTypes.Week;
     todayColor: string = "#000000";
+}
+
+export class customXaxisSettings {
+    show: boolean = true;
+    axisRangeType: string = "auto";
+    axisRangeTypeAbsoluteStartDate: string = "1 Jan 2018";
+    axisRangeTypeAbsoluteEndDate: string = "31 Dec 2020";
+    axisRangeTypeRelativeReferenceDateMethod: string = "Current date";
+    axisRangeTypeRelativeStartInt: number = -1;
+    axisRangeTypeRelativeEndInt: number = 3;
+    axisShow: boolean = true;
     axisColor: string = "#000000";
     axisTextColor: string = "#000000";
+}
+export class PlotAreaSettings {
+    show: boolean = true;
+    paShowBandedColumns: boolean = false;
+    paColorOdd: string = "#ff0000";
+    paColorEven: string = "#00ff00";
+    transparency: number = 20;
 }
 
 export class TooltipConfigSettings {


### PR DESCRIPTION
Management wants to have a timeframe view of multiple projects.
Therefore I created a timeframe view:  specify the amount of intervals to look forward or backward in time.
In my case: I want to see the projects that run from 1 quarter ago until 4 quarters ahead.

Also, there are some more options to format the X-axis in the visual formatting options.

To make the timeframe view better readable I added the ability to format the plot background with banded columns. Set your favorite colours and specify the transparency :-)

![image](https://user-images.githubusercontent.com/52189633/61001704-6ea4e900-a360-11e9-9b0e-dd6d148c48d5.png)

Please do comment :-)
